### PR TITLE
异常捕获的代码优化

### DIFF
--- a/xxl-job-core/src/main/java/com/xxl/job/core/server/EmbedServer.java
+++ b/xxl-job-core/src/main/java/com/xxl/job/core/server/EmbedServer.java
@@ -91,7 +91,7 @@ public class EmbedServer {
                     // wait util stop
                     future.channel().closeFuture().sync();
 
-                } catch (InterruptedException e) {
+                } catch (Exception e) {
                     if (e instanceof InterruptedException) {
                         logger.info(">>>>>>>>>>> xxl-job remoting server stop.");
                     } else {


### PR DESCRIPTION
捕获 InterruptedException 异常，然后下面  "e instanceof InterruptedException"，肯定是只走这个分支的
 catch (InterruptedException e) {
                    if (e instanceof InterruptedException) {
                        logger.info(">>>>>>>>>>> xxl-job remoting server stop.");
                    } else {
                        logger.error(">>>>>>>>>>> xxl-job remoting server error.", e);
                    }
                }

**What kind of change does this PR introduce?** (check at least one)

- 

- [√ ] Bugfix
- [√ ] Feature
- [√ ] Code style update
- [√ ] Refactor
- [√ ] Build-related changes
- [√ ] Other, please describe:


**The description of the PR:**


**Other information:**